### PR TITLE
Reworked Dockerfile to optimize workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 FROM ubuntu
 
-RUN apt-get update
-RUN apt-get install -y build-essential git
-RUN apt-get install -y libelf-dev gcc-avr avr-libc
-RUN apt-get install -y arduino arduino-mk
-RUN apt-get install -y socat
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  libelf-dev gcc-avr avr-libc \
+  arduino-mk \
+  socat
+
+EXPOSE 3000
+
+VOLUME ["/simreprap"]
+
+CMD ["bash", "-c", "socat tcp-l:3000,reuseaddr,fork /tmp/simavr-uart0 & (cd /simreprap && make && ./obj-x86_64-linux-gnu/reprap.elf)"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,37 @@
-# Dependencies required to compile under Ubuntu Trusty
+# Using the Dockerfile
+
+## Building the image
 
 ```bash
-$ sudo apt-get install libelf-dev gcc-avr avr-libc
+$ docker build -t simreprap .
 ```
+
+## Building and running the code
+
+```bash
+$ docker run --rm -v $PWD:/simreprap -p 3000:3000 -i -t simreprap
+```
+
+## Accessing the simulated serial port
+
+```bash
+$ telnet $(boot2docker ip) 3000
+Trying 192.168.59.103...
+Connected to 192.168.59.103.
+Escape character is '^]'.
+start
+echo:Marlin 1.0.0
+...
+```
+
+This assumes `boot2docker`, you can just use `localhost` if running on the
+Docker host. Also, feel free to replace `telnet` with `nc`.
+
+## Exposing the simulated serial port as a virtual port on the host
+
+```bash
+$ socat pty,link=/tmp/simreprap tcp:$(boot2docker ip):3000
+```
+
+Then direct e.g. Pronterface to connect to the "port" at /tmp/simreprap.
 


### PR DESCRIPTION
Note that this includes the change proposed in https://github.com/Morendil/simreprap/pull/5 as well.

This Dockerfile only runs `socat` and `simreprap` in the container,
and lets one edit and manage code on the host (hence the removal of
`git` from the dependency list) through a shared folder, Vagrant-style.
